### PR TITLE
feat: heartbeat alongside updates

### DIFF
--- a/hubitat/vivint-integration.groovy
+++ b/hubitat/vivint-integration.groovy
@@ -65,6 +65,11 @@ mappings {
         action: [
             POST: "handleUpdate"
         ]
+    },
+    path("/heartbeat") {
+        action: [
+            GET: "heartbeat"
+        ]
     }
 }
 
@@ -92,6 +97,7 @@ def initialize() {
         createAccessToken()
     }
     state.updateUrl = "${getFullLocalApiServerUrl()}/update?access_token=$state.accessToken"
+    state.heartbeatUrl = "${getFullLocalApiServerUrl()}/heartbeat?access_token=$state.accessToken"
     
     // Connect to server
     connectToServer()
@@ -136,7 +142,7 @@ def connectToServer() {
 
 def registerListener() {
     def listenerUrl = "${url}/listeners"
-    def listenerBody = [ url: state.updateUrl ]
+    def listenerBody = [ updateUrl: state.updateUrl, heartbeatUrl: state.heartbeatUrl ]
     logDebug("Posting to ${listenerUrl} with ${listenerBody}")
     try {
         httpPostJson(listenerUrl, listenerBody) { response ->

--- a/nodejs/config/default.json
+++ b/nodejs/config/default.json
@@ -2,5 +2,6 @@
     "platform": "Vivint",
     "username": "your-vivint-user@email.com",
     "password": "vivint-user-password",
-    "apiLoginRefreshSecs": 1200
+    "apiLoginRefreshSecs": 1200,
+    "heartbeatSecs": 60
 }

--- a/nodejs/lib/device_set.js
+++ b/nodejs/lib/device_set.js
@@ -65,10 +65,10 @@ function DeviceSetModule(config, log, vivintApi, listeners) {
       
       if (listenerData) {
         listeners.data.forEach((listener) => {
-          log.info(`Pushing update to ${listener.url}`)
-          log.debug(`Pushing update to ${listener.url}: ${JSON.stringify(listenerData)}`)
+          log.info(`Pushing update to ${listener.updateUrl}`)
+          log.debug(`Pushing update to ${listener.updateUrl}: ${JSON.stringify(listenerData)}`)
               
-          this.sendUpdateToListener(listener.url, listenerData)
+          this.sendUpdateToListener(listener.updateUrl, listenerData)
         })
       }
     }
@@ -118,10 +118,10 @@ function DeviceSetModule(config, log, vivintApi, listeners) {
       
           if (listenerData) {
             listeners.data.forEach((listener) => {
-              log.info(`Pushing update to ${listener.url}`)
-              log.debug(`Pushing update to ${listener.url}: ${JSON.stringify(listenerData)}`)
+              log.info(`Pushing update to ${listener.updateUrl}`)
+              log.debug(`Pushing update to ${listener.updateUrl}: ${JSON.stringify(listenerData)}`)
               
-              this.sendUpdateToListener(listener.url, listenerData)
+              this.sendUpdateToListener(listener.updateUrl, listenerData)
             })
           }
         }
@@ -210,6 +210,7 @@ function DeviceSetModule(config, log, vivintApi, listeners) {
         log.error('Error occured sending data to listener: ${listenerUrl}', error)
       }
     }
+    
   }
 
   // let Devices = [ContactSensor, SmokeSensor, CarbonMonoxideSensor, MotionSensor, Lock, Thermostat, GarageDoor, Panel, Camera, LightSwitch, DimmerSwitch]


### PR DESCRIPTION
Updates from the NodeJS server trigger heartbeats only when updates are received from Vivint AND if those snapshots differ from the most recent snapshot.  If no updates from Vivint are received OR if updates are received but no changes are detected, then no updates will be sent to the HE integration, meaning no heartbeats.

If we repurpose the intent of the heartbeat to coincide with the uptime of the NodeJS server itself, rather than just the updates coming from Vivint, it would be a more accurate representation of what a heartbeat should be, and we will no longer receive spam messages complaining about the connection being offline (false positives).